### PR TITLE
Move dependencies to devDependencies

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -8,7 +8,7 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
+  "devDependencies": {
     "tslint": "^5.20.1",
     "typescript": "^3.7.2",
     "uglify-js": "^3.6.9"


### PR DESCRIPTION
Hi, thanks for the great project. I didn't see this package published on npm, so I'm doing a hacky setup to depend on this repo via the `dev/` folder. And it works fine, except that it seems like the deps should be marked as devDeps so that they don't get pulled in for production apps.